### PR TITLE
Fix outputCenters parsing

### DIFF
--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -279,7 +279,7 @@ int colvarbias_restraint_centers_moving::init(std::string const &conf)
     }
   } else {
     target_centers.clear();
-    return COLVARS_OK;
+    //return COLVARS_OK; //This short circuits parsing outputCenters and outputAccumulatedWork in REUS simulations, and makes scripts fail that didn't use to fail.
   }
 
   get_keyval(conf, "outputCenters", b_output_centers, b_output_centers);


### PR DESCRIPTION
In replica exchange umbrella sampling simulations, it is useful to write out the center of the window to the traj file, so that the traj files alone give you an accounting of exchanges between windows, which used to be enabled by turning on "outputCenters". Since this is not a traditional moving window, currently the code skips parsing outputCenters input, since the return statement comes first. Commenting this out works for me, although I do not know what the TODO is referring to on line 287.